### PR TITLE
refactor: simplify to pass more work to llm core enabling tool use

### DIFF
--- a/llm_azure.py
+++ b/llm_azure.py
@@ -1,13 +1,12 @@
 import os
-from typing import Iterable, Iterator, List, Union, Optional
+from typing import Iterable, Iterator, List, Union
 
 import click
 import llm
 import yaml
 from llm import EmbeddingModel, hookimpl
-from llm.default_plugins.openai_models import AsyncChat, Chat, _Shared, not_nulls, combine_chunks
+from llm.default_plugins.openai_models import AsyncChat, Chat, _Shared
 from openai import AsyncAzureOpenAI, AzureOpenAI
-from llm.utils import remove_dict_none_values
 
 DEFAULT_KEY_ALIAS = "azure"
 DEFAULT_KEY_ENV_VAR = "AZURE_OPENAI_API_KEY"
@@ -121,127 +120,11 @@ class AzureShared(_Shared):
         else:
             return AzureOpenAI(**kwargs)
 
-    def build_kwargs(self, prompt, stream):
-        kwargs = dict(not_nulls(prompt.options))
-        json_object = kwargs.pop("json_object", None)
-        if "max_tokens" not in kwargs and self.default_max_tokens is not None:
-            kwargs["max_tokens"] = self.default_max_tokens
-        if json_object:
-            kwargs["response_format"] = {"type": "json_object"}
-        if stream:
-            # For Azure OpenAI, stream_options is generally supported now
-            # https://github.com/openai/openai-python/issues/1469 was resolved.
-            kwargs["stream_options"] = {"include_usage": True}
-        return kwargs
-
-    def execute(self, prompt, stream, response, conversation=None, key=None, async_override=False):
-        messages = []
-        current_system = None
-
-        # Handle conversation history and attachments
-        if conversation is not None:
-            for prev_response in conversation.responses:
-                if prev_response.attachments:
-                    attachment_message = []
-                    if prev_response.prompt.prompt:
-                        attachment_message.append(
-                            {"type": "text", "text": prev_response.prompt.prompt}
-                        )
-                    for attachment in prev_response.attachments:
-                        attachment_message.append(_attachment(attachment))
-                    messages.append({"role": "user", "content": attachment_message})
-                else:
-                    if (
-                        prev_response.prompt.system
-                        and prev_response.prompt.system != current_system
-                    ):
-                        messages.append(
-                            {"role": "system", "content": prev_response.prompt.system},
-                        )
-                        current_system = prev_response.prompt.system
-                    messages.append(
-                        {"role": "user", "content": prev_response.prompt.prompt},
-                    )
-
-                messages.append(
-                    {"role": "assistant", "content": prev_response.text_or_raise()}
-                )
-
-        # Handle system prompt
-        if prompt.system and prompt.system != current_system:
-            messages.append({"role": "system", "content": prompt.system})
-
-        # Handle attachments for current prompt
-        if not prompt.attachments:
-            messages.append({"role": "user", "content": prompt.prompt})
-        else:
-            attachment_message = []
-            if prompt.prompt:
-                attachment_message.append({"type": "text", "text": prompt.prompt})
-            for attachment in prompt.attachments:
-                attachment_message.append(_attachment(attachment))
-            messages.append({"role": "user", "content": attachment_message})
-
-        response._prompt_json = {"messages": messages}
-        kwargs = self.build_kwargs(prompt, stream)
-        client = self.get_client(key=key, async_=async_override) # key is now passed
-
-        if async_override:
-            async def async_generator():
-                completion = await client.chat.completions.create(
-                    model=self.model_name or self.model_id,
-                    messages=messages,
-                    stream=True,
-                    **kwargs,
-                )
-                chunks = []
-                async for chunk in completion:
-                    chunks.append(chunk)
-                    content = combine_chunks(chunks)
-                    yield content["content"] # Changed this line
-                response.response_json = remove_dict_none_values(
-                    combine_chunks(chunks)
-                )
-                response.usage = response.response_json.get("usage")
-            return async_generator()
-        else: # Synchronous execution
-            completion = client.chat.completions.create(
-                model=self.model_name or self.model_id,
-                messages=messages,
-                stream=stream, # Use the stream parameter for sync calls
-                **kwargs,
-            )
-            if stream:
-                chunks = []
-                for chunk in completion:
-                    chunks.append(chunk)
-                    content = combine_chunks(chunks)
-                    yield content["content"] # Changed this line
-                response.response_json = remove_dict_none_values(
-                    combine_chunks(chunks)
-                )
-                response.usage = response.response_json.get("usage")
-            else:
-                response.response_json = remove_dict_none_values(completion.model_dump())
-                yield completion.choices[0].message.content
-
-
 class AzureChat(AzureShared, Chat):
-    def __init__(self, *args, **kwargs):
-        # AzureChat now correctly inherits from AzureShared, which handles the new parameters
-        # and passes them up to the base _Shared (and thus Chat) class.
-        super().__init__(*args, **kwargs)
-
+    pass
 
 class AzureAsyncChat(AzureShared, AsyncChat):
-    def __init__(self, *args, **kwargs):
-        # AzureAsyncChat also correctly inherits from AzureShared.
-        super().__init__(*args, **kwargs)
-
-    async def execute(self, prompt, stream, response, conversation=None, key=None):
-        async for chunk in await super().execute(prompt, stream, response, conversation, key=key, async_override=True):
-            yield chunk
-
+    pass
 
 class AzureEmbedding(EmbeddingModel):
     batch_size = 100
@@ -263,22 +146,3 @@ class AzureEmbedding(EmbeddingModel):
         }
         results = client.embeddings.create(**kwargs).data
         return ([float(r) for r in result.embedding] for result in results)
-
-
-def _attachment(attachment):
-    url = attachment.url
-    base64_content = ""
-    if not url or attachment.resolve_type().startswith("audio/"):
-        base64_content = attachment.base64_content()
-        url = f"data:{attachment.resolve_type()};base64,{base64_content}"
-    if attachment.resolve_type().startswith("image/"):
-        return {"type": "image_url", "image_url": {"url": url}}
-    else:
-        format_ = "wav" if attachment.resolve_type() == "audio/wav" else "mp3"
-        return {
-            "type": "input_audio",
-            "input_audio": {
-                "data": base64_content,
-                "format": format_,
-            },
-        }


### PR DESCRIPTION
Hello, thanks for bringing the patches together. However, I think it is possible to simplify. If we just let the openai_models.py do the work, we should get attachments and e.g tool use for free. These work for me now:
```
❯ llm -m azure/gpt-4o-mini "describe this image" -a https://static.simonwillison.net/static/2024/pelicans.jpg

The image depicts a large group of birds gathered together on a rocky shore or a coastal area, with water visible in the background. There are several pelicans prominently featured, characterized by their long bills and distinctive body shape. The pelicans appear to be mingling with a multitude of smaller, dark-colored birds, which could possibly be shorebirds or seabirds. The setting seems to be a natural habitat, surrounded by water, suggesting a serene environment. The overall scene conveys a sense of community among the birds as they rest or interact with one another on the rocky surface. The lighting appears to be soft, indicating either early morning or late afternoon.
```
```
❯ llm --tool simple_eval -m azure/gpt-4o-mini "How much is 99*2244" --td

Tool call: simple_eval({'expression': '99*2244'})
  222156

99 multiplied by 2,244 equals 222,156.
```
```
- model_id: azure/gpt-4o-mini
  model_name: gpt-4o-mini
  api_base: <api_base>
  api_version: <api_version>
  vision: true
  supports_tools: true
  ```
